### PR TITLE
Removed ROOT.geometry call so that window would automatically resize.

### DIFF
--- a/bletchley-v1-083.py
+++ b/bletchley-v1-083.py
@@ -16,13 +16,12 @@ from tkinter import (
     messagebox,
 )
 
-from libs import music
-
 import string_utils
+
+from libs import music
 
 ROOT = Tk()
 ROOT.title("Bletchley v1.083")
-ROOT.geometry("225x520")
 
 # Define the available song filenames.
 available_songs = {


### PR DESCRIPTION
With the set geometry, the window was too small on my screen. By 
removing the set geometry, I enabled the window to assign its own size 
to dynamically fit the contents. This is much cleaner.